### PR TITLE
Download dependencies for all the public packages on npm

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const utils = require("./stuff/utils.js");
 const download_stars = require("./stuff/download_stars.js");
 const test_runner = require("./stuff/test_runner.js");
 const download_all = require("./stuff/download_all.js");
+const download_deps = require("./stuff/download_deps.js");
 const sift = require("./stuff/type_sorter.js");
 
 apiTokens = [
@@ -48,6 +49,7 @@ function help() {
     download_stars.help();
     test_runner.help();
     download_all.help();
+    download_deps.help();
 
     // Add your own actions here
     console.log("")
@@ -67,11 +69,14 @@ function main() {
         case "download":
             download_all.download(apiTokens);
             return;
-	case "downloadTestProjects":
-	    test_runner.downloadTestProjects(apiTokens);
-	case "git_js":
-	    download_all.git_js(apiTokens);
-	    return;
+        case "downloadTestProjects":
+            test_runner.downloadTestProjects(apiTokens);
+        case"downloadDeps":
+            download_deps.download();
+            return;
+        case "git_js":
+            download_all.git_js(apiTokens);
+            return;
         case "topStars":
             download_stars.download(apiTokens);
             break;
@@ -81,8 +86,8 @@ function main() {
         case "runTests":
             test_runner.runTests(false);
             break;
-	case "timeTests":
-	    test_runner.timeTests();
+        case "timeTests":
+            test_runner.timeTests();
         case "help":
             help();
             break;

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "async": "^2.5.0"
+    "JSONStream": "^1.3.2",
+    "async": "^2.6.0"
   }
 }

--- a/stuff/download_deps.js
+++ b/stuff/download_deps.js
@@ -38,7 +38,7 @@ module.exports = {
         console.log("Getting dependencies for all npm packages")
         let packages = {};
         let count = 0;
-        outdir = process.argv[3]
+        outDir = process.argv[3]
 
         child_process.spawn('curl', [NPM_REGISTRY_URL]).stdout
             .pipe(JSONStream.parse("rows.*"))

--- a/stuff/download_deps.js
+++ b/stuff/download_deps.js
@@ -1,0 +1,58 @@
+const JSONStream = require('JSONStream');
+const fs = require('fs');
+const child_process = require('child_process');
+const path = require('path')
+
+// Hosts package metadata for latest versions of all public packages on NPM
+const NPM_REGISTRY_URL = "https://skimdb.npmjs.com/registry/_design/scratch/_view/byField";
+let outDir = "";
+
+module.exports = {
+
+    help: function() {
+        console.log("")
+        console.log("downloadDeps OUTPUT")
+        console.log("    Downloads dependencies and devDependencies of all public NPM packages")
+        console.log("    in OUTPUT/dependencies.json")
+    },
+
+    /**
+     * Downloads dependency information for all packages hosted on NPM and dumps them
+     * as a json file.
+     * File Format:
+     *      {
+     *          "pkgName":
+     *              {
+     *                  "version": 1.0.1,
+     *                  "dependencies": [...],
+     *                  "devDependencies": [...]
+     *             }
+     *      }
+     */
+    download : function() {
+        if (process.argv.length !== 4) {
+            module.exports.help();
+            console.log("Invalid number of arguments for downloadDeps action");
+            process.exit(-1);
+        }
+        console.log("Getting dependencies for all npm packages")
+        let packages = {};
+        let count = 0;
+        outdir = process.argv[3]
+
+        child_process.spawn('curl', [NPM_REGISTRY_URL]).stdout
+            .pipe(JSONStream.parse("rows.*"))
+            .on("data", (row) => {
+                process.stdout.write("Packages Processed: " + count++ + "\r")
+                packages[row.value.name] = {
+                    version: row.value.version,
+                    dependencies: row.value.dependencies || [],
+                    devDependencies: row.value.devDependencies || []
+                }
+            })
+            .on("end", () => {
+                fs.writeFileSync(path.join(outDir, "dependencies.json"),
+                                 JSON.stringify(packages, null, 2))
+            })
+    }
+}

--- a/stuff/download_deps.js
+++ b/stuff/download_deps.js
@@ -40,7 +40,7 @@ module.exports = {
         let count = 0;
         outDir = process.argv[3]
 
-        child_process.spawn('curl', [NPM_REGISTRY_URL]).stdout
+        child_process.spawn('curl', ["-s", NPM_REGISTRY_URL]).stdout
             .pipe(JSONStream.parse("rows.*"))
             .on("data", (row) => {
                 process.stdout.write("Packages Processed: " + count++ + "\r")

--- a/stuff/download_deps.js
+++ b/stuff/download_deps.js
@@ -12,8 +12,8 @@ module.exports = {
     help: function() {
         console.log("")
         console.log("downloadDeps OUTPUT")
-        console.log("    Downloads dependencies and devDependencies of all public NPM packages")
-        console.log("    in OUTPUT/dependencies.json")
+        console.log("    Downloads dependencies and devDependencies of latest versions of")
+        console.log("    all public NPM packages in OUTPUT/dependencies.json")
     },
 
     /**


### PR DESCRIPTION
The functionality for downloading the dependencies for all packages from npm resides in `stuff/download_deps.js`, which basically performs following steps:

- Download the skimdb mirror of npm registry by spawning a curl process
- Pipe the response to streaming json parser and extract package properties (name, version, dependencies, etc.)
- Write output to a json file

The script is integrated with index.js and can be used like so:

``` node index.js downloadDeps <OUT_DIR> ```