### PR TITLE
Add command to download NPM registry in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "umount_ramdisk": "umount /ramdisk && rm -rf /ramdisk",
     "download": "node --stack-size=1024000000 index.js download",
     "download_orange": "node --stack-size=1024000000 index.js download /home/peta/jsdownload/projects-js.csv --verbose --max-workers=80 --max-w=10 --stride=100 --skip-existing --clear-tmp-dir --github-tokens=/home/peta/jsdownload/github-tokens.json --out-dir=/home/peta/jsdownload ",
-    "download_ginger": "node --stack-size=1024000000 index.js download /mnt/data/jsd/projects-js.csv --verbose --max-workers=80 --max-w=10 --stride=100 --skip-existing --clear-tmp --github-tokens=/mnt/data/jsd/github-tokens.json --out-dir=/mnt/data/jsd/output "
+    "download_ginger": "node --stack-size=1024000000 index.js download /mnt/data/jsd/projects-js.csv --verbose --max-workers=80 --max-w=10 --stride=100 --skip-existing --clear-tmp --github-tokens=/mnt/data/jsd/github-tokens.json --out-dir=/mnt/data/jsd/output ",
+    "download_npm_registry": "curl https://skimdb.npmjs.com/registry/_design/scratch/_view/byField -o npm-registry.json"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
I thought adding the curl command in `package.json` is a better idea out of the two options you mentioned in the previous pull request.

It takes a few minutes to download it so I didn't think it's worth running the command post-install. But I could be wrong. Let me know, thanks a lot!